### PR TITLE
fix module path by adding module name

### DIFF
--- a/ec2_route53_sync/cli/__init__.py
+++ b/ec2_route53_sync/cli/__init__.py
@@ -35,7 +35,8 @@ def get_zone_records(zone_id):
                       and 'AliasTarget' not in r]
         if not rrs['IsTruncated']:
             break
-        rrs = r53_client.list_resource_record_sets(HostedZoneId=zone_id, StartRecordName=rrs['NextRecordName'])
+        rrs = r53_client.list_resource_record_sets(
+                HostedZoneId=zone_id, StartRecordName=rrs['NextRecordName'])
 
     return set(HostIP(r['Name'].split('.')[0], rr['Value'])
                for r in a_records
@@ -48,7 +49,8 @@ def get_tag_zone_diff(hostname_tag,
                       name_is_fqdn,
                       include_ec2,
                       vpc_ids):
-    hosts_from_tag = get_ec2_hosts(vpc_ids, hostname_tag, name_is_fqdn, include_ec2)
+    hosts_from_tag = get_ec2_hosts(
+            vpc_ids, hostname_tag, name_is_fqdn, include_ec2)
     hosts_from_zone, a_records = get_zone_records(zone_id)
     hosts_to_add = hosts_from_tag - hosts_from_zone
     hosts_to_prune = hosts_from_zone - hosts_from_tag
@@ -59,8 +61,10 @@ def apply_zone_changes(zone_id, changes, batch_size=100):
     changes_size = len(changes)
     for i in range(0, changes_size, batch_size):
         change_batch = changes[i:min(i+batch_size, changes_size)]
-        print("changes[{}:{}]: {}".format(i, min(i+batch_size, changes_size), change_batch[0]))
-        r53_client.change_resource_record_sets(HostedZoneId=zone_id, ChangeBatch={'Changes': change_batch})
+        print("changes[{}:{}]: {}".format(
+            i, min(i+batch_size, changes_size), change_batch[0]))
+        r53_client.change_resource_record_sets(
+                HostedZoneId=zone_id, ChangeBatch={'Changes': change_batch})
 
 
 @click.command()

--- a/ec2_route53_sync/cli/__init__.py
+++ b/ec2_route53_sync/cli/__init__.py
@@ -1,13 +1,10 @@
 import boto3
 import click
-from .models import (
-    HostIP,
-)
-from .utils import (
-    create_merged_diff,
-    create_zone_changes,
-    get_instance_tag,
-)
+
+from ec2_route53_sync.models import HostIP
+from ec2_route53_sync.utils import create_merged_diff
+from ec2_route53_sync.utils import create_zone_changes
+from ec2_route53_sync.utils import get_instance_tag
 
 ec2_client = boto3.client('ec2')
 r53_client = boto3.client('route53')


### PR DESCRIPTION
previously packages imported on `ec2_route53_sync/cli/__init__.py` only using `from .models import` as its path. it will cause error since `.` in front of package name means python will treat the package as the current packages' subdirectory